### PR TITLE
Remove Accelerated - IR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "summit",
-  "version": "0.1.30",
+  "version": "0.1.80",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "summit",
-      "version": "0.1.30",
+      "version": "0.1.80",
       "dependencies": {
         "@astrojs/alpinejs": "^0.4.0",
         "@astrojs/mdx": "^3.1.9",
@@ -2864,9 +2864,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001668",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001668.tgz",
-      "integrity": "sha512-nWLrdxqCdblixUO+27JtGJJE/txpJlyUy5YN1u53wLZkP0emYCo5zgS6QYft7VUYR42LGgi/S5hdLZTrnyIddw==",
+      "version": "1.0.30001709",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001709.tgz",
+      "integrity": "sha512-NgL3vUTnDrPCZ3zTahp4fsugQ4dc7EKTSzwQDPEel6DMoMnfH2jhry9n2Zm8onbSR+f/QtKHFOA+iAQu4kbtWA==",
       "funding": [
         {
           "type": "opencollective",

--- a/src/data/instrumentPackages.js
+++ b/src/data/instrumentPackages.js
@@ -11,7 +11,7 @@ const instrumentPackages = {
           "Based on how often you can fly per week, how quickly do you want to earn your Instrument Rating?",
         options: [
           " ",
-          "2 weeks of full-time training by flying daily",
+          /* "2 weeks of full-time training by flying daily", */
           "4 months flexible training by flying 2-3 days per week",
         ],
       },
@@ -31,7 +31,7 @@ const instrumentPackages = {
     "Non-owned Insurance",
   ],
   packs: [
-    {
+    /* {
       packageName: "Accelerated Package",
       option: "2 weeks of full-time training by flying daily",
       monthlyPrice: {
@@ -55,7 +55,7 @@ const instrumentPackages = {
       ],
       packageLittlePrint:
         "*Contact Summit Flight Academy for scheduling availability on this program. Significant advanced planning required. Two weeks of dedicated, full time effort is needed to complete this program. You will complete multiple flights and ground school each day to complete the program in two weeks. It is expected that you will sit for your checkride at the end of the two weeks. Advanced scheduling for this program is required in order to secure a checkride date and instructor/aircraft availability.",
-    },
+    }, */
     {
       packageName: "Efficient Package",
       option: "4 months flexible training by flying 2-3 days per week",


### PR DESCRIPTION
This pull request includes changes to the `src/data/instrumentPackages.js` file to temporarily disable the "Accelerated Package" option in the instrument training packages. The most important changes are as follows:

Changes to instrument training packages:

* Commented out the "2 weeks of full-time training by flying daily" option in the `options` array.
* Commented out the entire "Accelerated Package" object in the `packs` array. [[1]](diffhunk://#diff-36f83b751be01791fc7f8c9051135d36b0c6abf5b697b5b6b29c6299f5ef7770L34-R34) [[2]](diffhunk://#diff-36f83b751be01791fc7f8c9051135d36b0c6abf5b697b5b6b29c6299f5ef7770L58-R58)